### PR TITLE
only run 'test-utils' if 'test_all'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: repometrics
 Title: Metrics for Your Code Repository
-Version: 0.1.6.050
+Version: 0.1.6.051
 Authors@R: 
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/repometrics",
   "issueTracker": "https://github.com/ropensci-review-tools/repometrics/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.6.050",
+  "version": "0.1.6.051",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,3 +1,8 @@
+test_all <- (identical (Sys.getenv ("MPADGE_LOCAL"), "true") ||
+    identical (Sys.getenv ("GITHUB_JOB"), "test-coverage"))
+
+skip_if (!test_all)
+
 test_that ("author matches", { # R/cm-metric-cran-downloads.R
 
     dat <- mock_rm_data ()


### PR DESCRIPTION
Because this fails on r-universe machines because temp pkg dir already exists