### PR TITLE
merge 'PRs' field group into 'issues' [ci skip]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: repometrics
 Title: Metrics for Your Code Repository
-Version: 0.2.0.016
+Version: 0.2.0.017
 Authors@R: 
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/repometrics",
   "issueTracker": "https://github.com/ropensci-review-tools/repometrics/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.0.016",
+  "version": "0.2.0.017",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/inst/extdata/metrics-models/metrics-models.json
+++ b/inst/extdata/metrics-models/metrics-models.json
@@ -28,7 +28,7 @@
             "what": "count",
             "scale": "log",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "change_req_n_opened",
@@ -38,7 +38,7 @@
             "what": "count",
             "scale": "log",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "change_req_prop_code",
@@ -48,7 +48,7 @@
             "what": "ratio",
             "scale": "none",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "change_req_prop_merged",
@@ -58,7 +58,7 @@
             "what": "ratio",
             "scale": "none",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "code_change_lines",
@@ -358,7 +358,7 @@
             "what": "ratio",
             "scale": "none",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "pr_cmt_count",
@@ -378,7 +378,7 @@
             "what": "days",
             "scale": "log",
             "better": "lower",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "pr_review_duration",
@@ -388,7 +388,7 @@
             "what": "days",
             "scale": "log",
             "better": "lower",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "pr_reviews_approved",
@@ -398,7 +398,7 @@
             "what": "count",
             "scale": "log",
             "better": "higher",
-            "field_group": "PRs"
+            "field_group": "issues"
         },
         {
             "name": "pr_revs_rejected",


### PR DESCRIPTION
First run of orgmetrics data shows PRs fields are mostly uninformative anyway, so better to merge all into single 'issues' group