### PR TITLE
fix pagination for gh rest api

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: repometrics
 Title: Metrics for Your Code Repository
-Version: 0.2.0.031
+Version: 0.2.0.032
 Authors@R: 
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2172-5265"))

--- a/R/utils-github.R
+++ b/R/utils-github.R
@@ -61,6 +61,7 @@ gh_next_page <- function (resp) {
             ptn <- "<([^>]+)>"
             next_page <- regmatches (link, regexpr (ptn, link))
             next_page <- gsub ("^.*&page\\=|>", "", next_page)
+            next_page <- gsub ("\\&after\\=.*$", "", next_page)
         }
     }
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/repometrics",
   "issueTracker": "https://github.com/ropensci-review-tools/repometrics/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.0.031",
+  "version": "0.2.0.032",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
It sometimes return 'after=<hash>', even though docs say nothing about that; https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api